### PR TITLE
[S1] Docker Compose local environment

### DIFF
--- a/apps/backend-api/Dockerfile
+++ b/apps/backend-api/Dockerfile
@@ -1,19 +1,26 @@
 FROM python:3.12-slim
 
+# Install system dependencies required by asyncpg and PostGIS client libs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
-# Install uv
+# Install uv for fast dependency resolution
 RUN pip install uv --no-cache-dir
 
-# Copy dependency files
+# Copy dependency manifest first to leverage layer cache
 COPY pyproject.toml .
 
-# Install dependencies
+# Install all dependencies (including dev extras for hot-reload tooling)
 RUN uv pip install --system -e ".[dev]"
 
-# Copy source
+# Copy source — in dev this is overridden by a bind mount
 COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# Default: hot reload enabled. Override CMD in production.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/infra/docker/.env.example
+++ b/infra/docker/.env.example
@@ -3,6 +3,26 @@
 # Copy to .env and fill in your values
 # =============================================================
 
+# --- PostgreSQL ---
+POSTGRES_DB=barcutx_dev
 POSTGRES_USER=barcutx
 POSTGRES_PASSWORD=barcutx_dev
-POSTGRES_DB=barcutx_dev
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+# --- Redis ---
+REDIS_URL=redis://redis:6379
+
+# --- Database (SQLAlchemy async) ---
+DATABASE_URL=postgresql+asyncpg://barcutx:barcutx_dev@postgres:5432/barcutx_dev
+
+# --- Supabase (placeholders — fill with real values) ---
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_KEY=your-service-role-key
+
+# --- Auth ---
+SECRET_KEY=change-me-in-production-use-openssl-rand-hex-32
+
+# --- App ---
+ENVIRONMENT=development

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: supabase/postgres:15.8.1.020
+    image: postgis/postgis:16-3.4-alpine
     container_name: barcutx-postgres
     restart: unless-stopped
     ports:
@@ -19,7 +19,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7.4-alpine
+    image: redis:7-alpine
     container_name: barcutx-redis
     restart: unless-stopped
     ports:
@@ -42,7 +42,7 @@ services:
     ports:
       - "8000:8000"
     env_file:
-      - ../../apps/backend-api/.env
+      - ../../apps/backend-api/.env.example
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-barcutx}:${POSTGRES_PASSWORD:-barcutx_dev}@postgres:5432/${POSTGRES_DB:-barcutx_dev}
       REDIS_URL: redis://redis:6379
@@ -55,6 +55,34 @@ services:
       - ../../apps/backend-api:/app
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
+  web:
+    build:
+      context: ../../apps/web-portal
+      dockerfile: Dockerfile
+    container_name: barcutx-web
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: development
+    depends_on:
+      - api
+    volumes:
+      - ../../apps/web-portal:/app
+      - web_node_modules:/app/node_modules
+    command: pnpm dev
+
+  adminer:
+    image: adminer:latest
+    container_name: barcutx-adminer
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
 volumes:
   postgres_data:
   redis_data:
+  web_node_modules:


### PR DESCRIPTION
## Summary
Completa el entorno local de Docker con todos los servicios necesarios para desarrollo.
Closes #2

## Changes
- PostgreSQL 16 con PostGIS (`postgis/postgis:16-3.4-alpine`)
- Redis 7 con persistencia AOF
- FastAPI con hot-reload via watchfiles
- Next.js web portal
- Adminer para gestión de DB (puerto 8080)
- `.env.example` completo con todas las variables
- Dockerfile actualizado con `libpq-dev` + `gcc` para asyncpg

## Testing
- [ ] Tests unitarios pasando
- [ ] `docker compose up` levanta sin errores
- [ ] API responde en `localhost:8000/health`
- [ ] Adminer accesible en `localhost:8080`

## Security Checklist
- [ ] Sin secrets expuestos (solo placeholders en .env.example)
- [ ] Variables de entorno para toda la configuración sensible