### PR TITLE
[S1] FastAPI base project setup

### DIFF
--- a/apps/backend-api/app/main.py
+++ b/apps/backend-api/app/main.py
@@ -40,7 +40,28 @@ app.add_middleware(
 
 @app.get("/health", tags=["system"])
 async def health_check() -> dict[str, str]:
-    return {"status": "ok", "version": "0.1.0"}
+    from sqlalchemy import text
+    from app.core.database import AsyncSessionLocal
+    from app.core.redis import get_redis
+
+    db_status = "disconnected"
+    redis_status = "disconnected"
+
+    try:
+        async with AsyncSessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+        db_status = "connected"
+    except Exception as e:
+        log.warning("health_check_db_failed", error=str(e))
+
+    try:
+        redis = get_redis()
+        await redis.ping()
+        redis_status = "connected"
+    except Exception as e:
+        log.warning("health_check_redis_failed", error=str(e))
+
+    return {"status": "ok", "db": db_status, "redis": redis_status, "version": "0.1.0"}
 
 
 # Routers (registered in Fase 1)

--- a/apps/backend-api/tests/conftest.py
+++ b/apps/backend-api/tests/conftest.py
@@ -1,7 +1,21 @@
+import os
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.main import app
+# Set required env vars before importing the app
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("SUPABASE_URL", "https://test.supabase.co")
+os.environ.setdefault("SUPABASE_ANON_KEY", "test-anon-key")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "test-service-key")
+os.environ.setdefault("SUPABASE_JWT_SECRET", "test-jwt-secret")
+os.environ.setdefault("STRIPE_SECRET_KEY", "sk_test_dummy")
+os.environ.setdefault("STRIPE_WEBHOOK_SECRET", "whsec_test_dummy")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
+os.environ.setdefault("ENVIRONMENT", "test")
+
+from app.main import app  # noqa: E402
+
 
 
 @pytest.fixture

--- a/apps/backend-api/tests/test_health.py
+++ b/apps/backend-api/tests/test_health.py
@@ -1,0 +1,51 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.anyio
+async def test_health_returns_ok(client: AsyncClient) -> None:
+    with (
+        patch("app.core.database.AsyncSessionLocal") as mock_session_factory,
+        patch("app.core.redis.get_redis") as mock_get_redis,
+    ):
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+        mock_session_factory.return_value = mock_session
+
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "db" in data
+    assert "redis" in data
+
+
+@pytest.mark.anyio
+async def test_health_db_disconnected_still_returns_ok(client: AsyncClient) -> None:
+    with (
+        patch("app.core.database.AsyncSessionLocal") as mock_session_factory,
+        patch("app.core.redis.get_redis") as mock_get_redis,
+    ):
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(side_effect=Exception("DB unreachable"))
+        mock_session_factory.return_value = mock_session
+
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["db"] == "disconnected"

--- a/apps/backend-api/tests/test_health.py
+++ b/apps/backend-api/tests/test_health.py
@@ -4,7 +4,7 @@ import pytest
 from httpx import AsyncClient
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_health_returns_ok(client: AsyncClient) -> None:
     with (
         patch("app.core.database.AsyncSessionLocal") as mock_session_factory,
@@ -29,7 +29,7 @@ async def test_health_returns_ok(client: AsyncClient) -> None:
     assert "redis" in data
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_health_db_disconnected_still_returns_ok(client: AsyncClient) -> None:
     with (
         patch("app.core.database.AsyncSessionLocal") as mock_session_factory,


### PR DESCRIPTION
## Summary
Completa el endpoint `/health` con verificación real de DB y Redis, más tests unitarios.
Closes #3

## Changes
- `GET /health` ahora verifica conexión a DB (`SELECT 1`) y Redis (`PING`)
- Retorna `{"status":"ok","db":"connected","redis":"connected","version":"0.1.0"}`
- Degradación graceful: retorna 200 aunque algún servicio esté caído
- `tests/test_health.py`: happy path + caso DB desconectada

## Testing
- [ ] Tests unitarios pasando (`pytest -v`)
- [ ] Happy path: health retorna 200 con db y redis connected
- [ ] Edge case: DB caída retorna 200 con db disconnected

## Security Checklist
- [ ] Sin secrets expuestos
- [ ] Variables de entorno para toda la config