### PR TITLE
[S1] Database schema inicial con Alembic migrations

### DIFF
--- a/apps/backend-api/alembic/versions/001_initial_schema.py
+++ b/apps/backend-api/alembic/versions/001_initial_schema.py
@@ -1,0 +1,118 @@
+"""initial schema
+
+Revision ID: 001
+Revises:
+Create Date: 2026-03-24
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Enable PostGIS and uuid-ossp
+    op.execute("CREATE EXTENSION IF NOT EXISTS postgis")
+    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+
+    # user_role enum
+    op.execute("CREATE TYPE user_role AS ENUM ('client', 'barber', 'barbershop_owner', 'admin')")
+
+    # users
+    op.create_table(
+        "users",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("supabase_id", sa.String(36), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("role", sa.Enum("client", "barber", "barbershop_owner", "admin", name="user_role"), nullable=False, server_default="client"),
+        sa.Column("full_name", sa.String(255), nullable=True),
+        sa.Column("phone", sa.String(20), nullable=True),
+        sa.Column("avatar_url", sa.String(500), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_users_supabase_id", "users", ["supabase_id"], unique=True)
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+
+    # barbershops
+    op.create_table(
+        "barbershops",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("owner_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("slug", sa.String(255), nullable=False),
+        sa.Column("description", sa.String(1000), nullable=True),
+        sa.Column("address", sa.String(500), nullable=False),
+        sa.Column("city", sa.String(100), nullable=False),
+        sa.Column("location", sa.Column("location", sa.String()), nullable=True),
+        sa.Column("logo_url", sa.String(500), nullable=True),
+        sa.Column("cover_url", sa.String(500), nullable=True),
+        sa.Column("stripe_account_id", sa.String(100), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_barbershops_slug", "barbershops", ["slug"], unique=True)
+    op.create_index("ix_barbershops_owner_id", "barbershops", ["owner_id"])
+    # PostGIS spatial index (created after adding geometry column)
+    op.execute("ALTER TABLE barbershops ALTER COLUMN location TYPE geometry(Point, 4326) USING NULL")
+    op.execute("CREATE INDEX ix_barbershops_location ON barbershops USING GIST (location)")
+
+    # business_hours
+    op.create_table(
+        "business_hours",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("barbershop_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("barbershops.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("day_of_week", sa.Integer(), nullable=False),
+        sa.Column("open_time", sa.Time(), nullable=False),
+        sa.Column("close_time", sa.Time(), nullable=False),
+        sa.Column("is_closed", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.create_index("ix_business_hours_barbershop_id", "business_hours", ["barbershop_id"])
+
+    # barbers
+    op.create_table(
+        "barbers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("barbershop_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("barbershops.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("bio", sa.String(500), nullable=True),
+        sa.Column("photo_url", sa.String(500), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_barbers_user_id", "barbers", ["user_id"], unique=True)
+    op.create_index("ix_barbers_barbershop_id", "barbers", ["barbershop_id"])
+
+    # services
+    op.create_table(
+        "services",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("uuid_generate_v4()")),
+        sa.Column("barbershop_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("barbershops.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.String(500), nullable=True),
+        sa.Column("price", sa.Numeric(10, 2), nullable=False),
+        sa.Column("duration_minutes", sa.Integer(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_services_barbershop_id", "services", ["barbershop_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("services")
+    op.drop_table("barbers")
+    op.drop_table("business_hours")
+    op.execute("DROP INDEX IF EXISTS ix_barbershops_location")
+    op.drop_table("barbershops")
+    op.drop_table("users")
+    op.execute("DROP TYPE IF EXISTS user_role")

--- a/apps/backend-api/app/modules/barber_shops/models.py
+++ b/apps/backend-api/app/modules/barber_shops/models.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime, time
+
+from geoalchemy2 import Geometry
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Time, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class BarberShop(Base):
+    __tablename__ = "barbershops"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    owner_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    description: Mapped[str | None] = mapped_column(String(1000), nullable=True)
+    address: Mapped[str] = mapped_column(String(500), nullable=False)
+    city: Mapped[str] = mapped_column(String(100), nullable=False)
+    location: Mapped[object | None] = mapped_column(Geometry(geometry_type="POINT", srid=4326), nullable=True)
+    logo_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    cover_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    stripe_account_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+
+class BusinessHours(Base):
+    __tablename__ = "business_hours"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    barbershop_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("barbershops.id", ondelete="CASCADE"), nullable=False, index=True)
+    day_of_week: Mapped[int] = mapped_column(Integer, nullable=False)  # 0=Monday, 6=Sunday
+    open_time: Mapped[time] = mapped_column(Time, nullable=False)
+    close_time: Mapped[time] = mapped_column(Time, nullable=False)
+    is_closed: Mapped[bool] = mapped_column(nullable=False, default=False)

--- a/apps/backend-api/app/modules/barbers/models.py
+++ b/apps/backend-api/app/modules/barbers/models.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Barber(Base):
+    __tablename__ = "barbers"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, unique=True, index=True)
+    barbershop_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("barbershops.id", ondelete="CASCADE"), nullable=False, index=True)
+    bio: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    photo_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/apps/backend-api/app/modules/services/models.py
+++ b/apps/backend-api/app/modules/services/models.py
@@ -1,0 +1,22 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Service(Base):
+    __tablename__ = "services"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    barbershop_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("barbershops.id", ondelete="CASCADE"), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    price: Mapped[float] = mapped_column(Numeric(10, 2), nullable=False)
+    duration_minutes: Mapped[int] = mapped_column(Integer, nullable=False)  # min 15
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/apps/backend-api/app/modules/users/models.py
+++ b/apps/backend-api/app/modules/users/models.py
@@ -1,0 +1,31 @@
+import enum
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class UserRole(str, enum.Enum):
+    client = "client"
+    barber = "barber"
+    barbershop_owner = "barbershop_owner"
+    admin = "admin"
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    supabase_id: Mapped[str] = mapped_column(String(36), unique=True, nullable=False, index=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    role: Mapped[UserRole] = mapped_column(Enum(UserRole, name="user_role"), nullable=False, default=UserRole.client)
+    full_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    avatar_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    is_active: Mapped[bool] = mapped_column(nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)


### PR DESCRIPTION
## Summary
Implementa los modelos SQLAlchemy y la migración inicial con todas las tablas base.
Closes #5

## Changes
- **User**: uuid pk, supabase_id, email, role enum (client/barber/barbershop_owner/admin)
- **BarberShop**: slug único, PostGIS geometry point (SRID 4326), stripe_account_id
- **BusinessHours**: horarios por día (0=lunes, 6=domingo) por barbería
- **Barber**: vincula user + barbershop, bio, photo_url
- **Service**: nombre, precio (Numeric 10,2), duración mínima en minutos
- Migración `001_initial_schema`: crea todas las tablas, índices, GIST index en `location`
- Habilita extensiones PostGIS y uuid-ossp

## Testing
- [ ] `alembic upgrade head` ejecuta sin errores contra PostgreSQL+PostGIS
- [ ] Tablas visibles en DB

## Security Checklist
- [ ] FKs con `ondelete=CASCADE` donde aplica
- [ ] Sin datos sensibles en la migración