### PR TITLE
[S2] Sistema de servicios y precios

### DIFF
--- a/apps/backend-api/app/api/v1/services.py
+++ b/apps/backend-api/app/api/v1/services.py
@@ -1,0 +1,104 @@
+import uuid
+from typing import Annotated
+
+import structlog
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_db
+from app.core.security import UserPayload, get_current_user
+from app.modules.services.schemas import ServiceCreate, ServiceResponse, ServiceUpdate
+from app.modules.services.service import ServiceService
+
+log = structlog.get_logger()
+
+router = APIRouter(tags=["services"])
+
+
+def _get_service(session: AsyncSession = Depends(get_db)) -> ServiceService:
+    return ServiceService(session)
+
+
+@router.get(
+    "/barber-shops/{shop_id}/services",
+    response_model=list[ServiceResponse],
+    status_code=status.HTTP_200_OK,
+    summary="List active services of a barber shop (public)",
+)
+async def list_services(
+    shop_id: uuid.UUID,
+    svc: Annotated[ServiceService, Depends(_get_service)],
+) -> list[ServiceResponse]:
+    return await svc.list_services(shop_id)
+
+
+@router.post(
+    "/barber-shops/{shop_id}/services",
+    response_model=ServiceResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a service for a barber shop (owner only)",
+)
+async def create_service(
+    shop_id: uuid.UUID,
+    data: ServiceCreate,
+    svc: Annotated[ServiceService, Depends(_get_service)],
+    current_user: Annotated[UserPayload, Depends(get_current_user)],
+) -> ServiceResponse:
+    log.info("create_service_request", shop_id=str(shop_id), user_id=str(current_user.id))
+    return await svc.create_service(shop_id, data, str(current_user.id))
+
+
+@router.get(
+    "/barber-shops/{shop_id}/services/{service_id}",
+    response_model=ServiceResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get a single service detail",
+)
+async def get_service(
+    shop_id: uuid.UUID,
+    service_id: uuid.UUID,
+    svc: Annotated[ServiceService, Depends(_get_service)],
+) -> ServiceResponse:
+    return await svc.get_service(shop_id, service_id)
+
+
+@router.patch(
+    "/barber-shops/{shop_id}/services/{service_id}",
+    response_model=ServiceResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update a service (owner only)",
+)
+async def update_service(
+    shop_id: uuid.UUID,
+    service_id: uuid.UUID,
+    data: ServiceUpdate,
+    svc: Annotated[ServiceService, Depends(_get_service)],
+    current_user: Annotated[UserPayload, Depends(get_current_user)],
+) -> ServiceResponse:
+    log.info(
+        "update_service_request",
+        shop_id=str(shop_id),
+        service_id=str(service_id),
+        user_id=str(current_user.id),
+    )
+    return await svc.update_service(shop_id, service_id, data, str(current_user.id))
+
+
+@router.delete(
+    "/barber-shops/{shop_id}/services/{service_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Deactivate a service (owner only)",
+)
+async def delete_service(
+    shop_id: uuid.UUID,
+    service_id: uuid.UUID,
+    svc: Annotated[ServiceService, Depends(_get_service)],
+    current_user: Annotated[UserPayload, Depends(get_current_user)],
+) -> None:
+    log.info(
+        "delete_service_request",
+        shop_id=str(shop_id),
+        service_id=str(service_id),
+        user_id=str(current_user.id),
+    )
+    await svc.delete_service(shop_id, service_id, str(current_user.id))

--- a/apps/backend-api/app/main.py
+++ b/apps/backend-api/app/main.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
@@ -8,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.core.config import settings
 from app.core.database import engine
 from app.core.logging import configure_logging
+from app.core.websocket_manager import ws_manager
 
 log = structlog.get_logger()
 
@@ -16,7 +18,13 @@ log = structlog.get_logger()
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configure_logging()
     log.info("barcutx_api_starting", environment=settings.environment)
+    redis_task = asyncio.create_task(ws_manager.listen_redis())
     yield
+    redis_task.cancel()
+    try:
+        await redis_task
+    except asyncio.CancelledError:
+        pass
     await engine.dispose()
     log.info("barcutx_api_stopped")
 
@@ -41,6 +49,7 @@ app.add_middleware(
 @app.get("/health", tags=["system"])
 async def health_check() -> dict[str, str]:
     from sqlalchemy import text
+
     from app.core.database import AsyncSessionLocal
     from app.core.redis import get_redis
 
@@ -64,6 +73,27 @@ async def health_check() -> dict[str, str]:
     return {"status": "ok", "db": db_status, "redis": redis_status, "version": "0.1.0"}
 
 
-# Routers (registered in Fase 1)
-# from app.api.v1 import router as api_v1_router
-# app.include_router(api_v1_router, prefix="/api/v1")
+# Auth — issue #8
+from app.api.v1.auth import router as auth_router  # noqa: E402
+
+app.include_router(auth_router, prefix="/api/v1")
+
+# Services — issue #10
+from app.api.v1.services import router as services_router  # noqa: E402
+
+app.include_router(services_router, prefix="/api/v1")
+
+# Barber Shops & Barbers — issue #9
+from app.api.v1.barber_shops import router as barber_shops_router  # noqa: E402
+
+app.include_router(barber_shops_router, prefix="/api/v1")
+
+# Appointments — issue #11
+from app.api.v1.appointments import router as appointments_router  # noqa: E402
+
+app.include_router(appointments_router, prefix="/api/v1")
+
+# Virtual Queue — issue #12
+from app.api.v1.queue import router as queue_router  # noqa: E402
+
+app.include_router(queue_router, prefix="/api/v1")

--- a/apps/backend-api/app/modules/services/repository.py
+++ b/apps/backend-api/app/modules/services/repository.py
@@ -1,0 +1,68 @@
+import uuid
+from decimal import Decimal
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.services.models import Service
+
+log = structlog.get_logger()
+
+
+class ServiceRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_active_by_shop(self, shop_id: uuid.UUID) -> list[Service]:
+        result = await self._session.execute(
+            select(Service)
+            .where(Service.barbershop_id == shop_id, Service.is_active.is_(True))
+            .order_by(Service.name)
+        )
+        return list(result.scalars().all())
+
+    async def get_by_id(self, service_id: uuid.UUID, shop_id: uuid.UUID) -> Service | None:
+        result = await self._session.execute(
+            select(Service).where(
+                Service.id == service_id,
+                Service.barbershop_id == shop_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        shop_id: uuid.UUID,
+        name: str,
+        description: str | None,
+        price: Decimal,
+        duration_minutes: int,
+    ) -> Service:
+        service = Service(
+            barbershop_id=shop_id,
+            name=name,
+            description=description,
+            price=price,
+            duration_minutes=duration_minutes,
+        )
+        self._session.add(service)
+        await self._session.flush()
+        await self._session.refresh(service)
+        log.info("service_created", service_id=str(service.id), shop_id=str(shop_id))
+        return service
+
+    async def update(self, service: Service, **fields: object) -> Service:
+        for key, value in fields.items():
+            if value is not None:
+                setattr(service, key, value)
+        await self._session.flush()
+        await self._session.refresh(service)
+        log.info("service_updated", service_id=str(service.id))
+        return service
+
+    async def deactivate(self, service: Service) -> Service:
+        service.is_active = False
+        await self._session.flush()
+        log.info("service_deactivated", service_id=str(service.id))
+        return service

--- a/apps/backend-api/app/modules/services/schemas.py
+++ b/apps/backend-api/app/modules/services/schemas.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ServiceCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = None
+    price: Decimal = Field(..., ge=Decimal("0"), decimal_places=2)
+    duration_minutes: int = Field(..., gt=0)
+
+
+class ServiceUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = None
+    price: Decimal | None = Field(None, ge=Decimal("0"), decimal_places=2)
+    duration_minutes: int | None = Field(None, gt=0)
+    is_active: bool | None = None
+
+
+class ServiceResponse(BaseModel):
+    id: UUID
+    shop_id: UUID
+    name: str
+    description: str | None
+    price: Decimal
+    duration_minutes: int
+    is_active: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/apps/backend-api/app/modules/services/service.py
+++ b/apps/backend-api/app/modules/services/service.py
@@ -1,0 +1,102 @@
+import uuid
+
+import structlog
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.barber_shops.models import BarberShop
+from app.modules.services.repository import ServiceRepository
+from app.modules.services.schemas import ServiceCreate, ServiceResponse, ServiceUpdate
+
+log = structlog.get_logger()
+
+
+async def _require_shop_owner(
+    session: AsyncSession,
+    shop_id: uuid.UUID,
+    user_id: str,
+) -> None:
+    """Raise 403 if user is not the owner of the shop, 404 if shop does not exist."""
+    from sqlalchemy import select
+
+    result = await session.execute(
+        select(BarberShop).where(BarberShop.id == shop_id)
+    )
+    shop = result.scalar_one_or_none()
+    if shop is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Barber shop not found")
+    if str(shop.owner_id) != user_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the shop owner")
+
+
+def _to_response(service: object) -> ServiceResponse:
+    """Map ORM Service to ServiceResponse, aliasing barbershop_id -> shop_id."""
+    return ServiceResponse(
+        id=service.id,  # type: ignore[attr-defined]
+        shop_id=service.barbershop_id,  # type: ignore[attr-defined]
+        name=service.name,  # type: ignore[attr-defined]
+        description=service.description,  # type: ignore[attr-defined]
+        price=service.price,  # type: ignore[attr-defined]
+        duration_minutes=service.duration_minutes,  # type: ignore[attr-defined]
+        is_active=service.is_active,  # type: ignore[attr-defined]
+        created_at=service.created_at,  # type: ignore[attr-defined]
+    )
+
+
+class ServiceService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._repo = ServiceRepository(session)
+        self._session = session
+
+    async def list_services(self, shop_id: uuid.UUID) -> list[ServiceResponse]:
+        services = await self._repo.list_active_by_shop(shop_id)
+        return [_to_response(s) for s in services]
+
+    async def get_service(self, shop_id: uuid.UUID, service_id: uuid.UUID) -> ServiceResponse:
+        service = await self._repo.get_by_id(service_id, shop_id)
+        if service is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Service not found")
+        return _to_response(service)
+
+    async def create_service(
+        self,
+        shop_id: uuid.UUID,
+        data: ServiceCreate,
+        user_id: str,
+    ) -> ServiceResponse:
+        await _require_shop_owner(self._session, shop_id, user_id)
+        service = await self._repo.create(
+            shop_id=shop_id,
+            name=data.name,
+            description=data.description,
+            price=data.price,
+            duration_minutes=data.duration_minutes,
+        )
+        return _to_response(service)
+
+    async def update_service(
+        self,
+        shop_id: uuid.UUID,
+        service_id: uuid.UUID,
+        data: ServiceUpdate,
+        user_id: str,
+    ) -> ServiceResponse:
+        await _require_shop_owner(self._session, shop_id, user_id)
+        service = await self._repo.get_by_id(service_id, shop_id)
+        if service is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Service not found")
+        update_fields = data.model_dump(exclude_none=True)
+        service = await self._repo.update(service, **update_fields)
+        return _to_response(service)
+
+    async def delete_service(
+        self,
+        shop_id: uuid.UUID,
+        service_id: uuid.UUID,
+        user_id: str,
+    ) -> None:
+        await _require_shop_owner(self._session, shop_id, user_id)
+        service = await self._repo.get_by_id(service_id, shop_id)
+        if service is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Service not found")
+        await self._repo.deactivate(service)

--- a/apps/backend-api/tests/test_services.py
+++ b/apps/backend-api/tests/test_services.py
@@ -1,0 +1,261 @@
+"""Unit tests for the services endpoints (issue #10)."""
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+SHOP_ID = str(uuid.uuid4())
+SERVICE_ID = str(uuid.uuid4())
+OWNER_ID = str(uuid.uuid4())
+
+VALID_PAYLOAD = {
+    "name": "Corte clasico",
+    "description": "Corte de cabello con tijera",
+    "price": "15.00",
+    "duration_minutes": 30,
+}
+
+
+def _make_service_response():
+    from app.modules.services.schemas import ServiceResponse
+
+    return ServiceResponse(
+        id=uuid.UUID(SERVICE_ID),
+        shop_id=uuid.UUID(SHOP_ID),
+        name="Corte clasico",
+        description="Corte de cabello con tijera",
+        price=Decimal("15.00"),
+        duration_minutes=30,
+        is_active=True,
+        created_at=datetime(2026, 3, 24, 10, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+def _override_db():
+    from app.core.database import get_db
+    from app.main import app
+
+    async def _fake_db():  # type: ignore[return]
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = _fake_db
+    return get_db
+
+
+def _override_auth(user_id: str = OWNER_ID):
+    from app.core.security import UserPayload, get_current_user
+    from app.main import app
+
+    async def _fake_auth() -> UserPayload:
+        return UserPayload(id=uuid.UUID(user_id), email="owner@test.com", role="owner")
+
+    app.dependency_overrides[get_current_user] = _fake_auth
+    return get_current_user
+
+
+def _clear_overrides():
+    from app.main import app
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/barber-shops/{shop_id}/services  (public)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_services_public(client: AsyncClient) -> None:
+    """Public endpoint returns 200 and a list of services without authentication."""
+    from app.modules.services.service import ServiceService
+
+    _override_db()
+
+    with patch.object(ServiceService, "list_services", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = [_make_service_response()]
+        response = await client.get(f"/api/v1/barber-shops/{SHOP_ID}/services")
+
+    _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["name"] == "Corte clasico"
+    assert data[0]["shop_id"] == SHOP_ID
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/barber-shops/{shop_id}/services
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_service_without_auth_returns_401(client: AsyncClient) -> None:
+    """POST without Authorization header must return 401."""
+    _override_db()
+
+    response = await client.post(
+        f"/api/v1/barber-shops/{SHOP_ID}/services",
+        json=VALID_PAYLOAD,
+    )
+
+    _clear_overrides()
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_create_service_with_auth(client: AsyncClient) -> None:
+    """POST with valid mock auth creates a service and returns 201."""
+    from app.modules.services.service import ServiceService
+
+    _override_db()
+    _override_auth()
+
+    with patch.object(ServiceService, "create_service", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = _make_service_response()
+
+        response = await client.post(
+            f"/api/v1/barber-shops/{SHOP_ID}/services",
+            json=VALID_PAYLOAD,
+            headers={"Authorization": "Bearer fake.jwt.token"},
+        )
+
+    _clear_overrides()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Corte clasico"
+    assert data["shop_id"] == SHOP_ID
+    assert data["price"] == "15.00"
+
+
+@pytest.mark.asyncio
+async def test_create_service_invalid_payload_returns_422(client: AsyncClient) -> None:
+    """POST with negative price must return 422 validation error."""
+    _override_db()
+    _override_auth()
+
+    response = await client.post(
+        f"/api/v1/barber-shops/{SHOP_ID}/services",
+        json={"name": "X", "price": "-5.00", "duration_minutes": 30},
+        headers={"Authorization": "Bearer fake.jwt.token"},
+    )
+
+    _clear_overrides()
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/v1/barber-shops/{shop_id}/services/{service_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_service(client: AsyncClient) -> None:
+    """PATCH with valid mock auth updates a service and returns 200."""
+    from app.modules.services.schemas import ServiceResponse
+    from app.modules.services.service import ServiceService
+
+    updated = ServiceResponse(
+        id=uuid.UUID(SERVICE_ID),
+        shop_id=uuid.UUID(SHOP_ID),
+        name="Corte premium",
+        description="Corte con navaja",
+        price=Decimal("20.00"),
+        duration_minutes=45,
+        is_active=True,
+        created_at=datetime(2026, 3, 24, 10, 0, 0, tzinfo=timezone.utc),
+    )
+
+    _override_db()
+    _override_auth()
+
+    with patch.object(ServiceService, "update_service", new_callable=AsyncMock) as mock_update:
+        mock_update.return_value = updated
+
+        response = await client.patch(
+            f"/api/v1/barber-shops/{SHOP_ID}/services/{SERVICE_ID}",
+            json={"name": "Corte premium", "price": "20.00", "duration_minutes": 45},
+            headers={"Authorization": "Bearer fake.jwt.token"},
+        )
+
+    _clear_overrides()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Corte premium"
+    assert data["price"] == "20.00"
+    assert data["duration_minutes"] == 45
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/barber-shops/{shop_id}/services/{service_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_service_without_auth_returns_401(client: AsyncClient) -> None:
+    """DELETE without auth must return 401."""
+    _override_db()
+
+    response = await client.delete(
+        f"/api/v1/barber-shops/{SHOP_ID}/services/{SERVICE_ID}",
+    )
+
+    _clear_overrides()
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_service_with_auth(client: AsyncClient) -> None:
+    """DELETE with valid mock auth deactivates a service and returns 204."""
+    from app.modules.services.service import ServiceService
+
+    _override_db()
+    _override_auth()
+
+    with patch.object(ServiceService, "delete_service", new_callable=AsyncMock) as mock_delete:
+        mock_delete.return_value = None
+
+        response = await client.delete(
+            f"/api/v1/barber-shops/{SHOP_ID}/services/{SERVICE_ID}",
+            headers={"Authorization": "Bearer fake.jwt.token"},
+        )
+
+    _clear_overrides()
+
+    assert response.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/barber-shops/{shop_id}/services/{service_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_service_not_found(client: AsyncClient) -> None:
+    """GET single service that does not exist returns 404."""
+    from fastapi import HTTPException
+    from app.modules.services.service import ServiceService
+
+    _override_db()
+
+    with patch.object(ServiceService, "get_service", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = HTTPException(status_code=404, detail="Service not found")
+
+        response = await client.get(
+            f"/api/v1/barber-shops/{SHOP_ID}/services/{SERVICE_ID}",
+        )
+
+    _clear_overrides()
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Service not found"

--- a/supabase/migrations/20260324000003_services.sql
+++ b/supabase/migrations/20260324000003_services.sql
@@ -1,0 +1,28 @@
+-- Migration: services table
+-- Created: 2026-03-24
+-- Issue: #10 - Sistema de servicios y precios
+
+CREATE TABLE IF NOT EXISTS public.services (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    shop_id UUID NOT NULL REFERENCES public.barber_shops(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    price NUMERIC(10, 2) NOT NULL CHECK (price >= 0),
+    duration_minutes INTEGER NOT NULL CHECK (duration_minutes > 0),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE public.services ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Anyone can view active services" ON public.services
+    FOR SELECT USING (is_active = TRUE);
+
+CREATE POLICY "Shop owners can manage services" ON public.services
+    FOR ALL USING (
+        EXISTS (
+            SELECT 1 FROM public.barber_shops
+            WHERE id = shop_id AND owner_id = auth.uid()
+        )
+    );


### PR DESCRIPTION
## Cambios
- CRUD completo de servicios por barberia: list, create, get, patch, delete
- Validacion de precio (>= 0, Decimal) y duracion (> 0) via Pydantic
- Autorizacion de owner: verifica que el shop pertenece al usuario autenticado antes de mutaciones
- Separacion de capas: repository -> service -> router
- RLS en migration SQL: owners gestionan, publico solo lee activos

## Tests
- `test_list_services_public` — GET sin auth retorna 200 con lista
- `test_create_service_without_auth_returns_401` — POST sin token retorna 401
- `test_create_service_with_auth` — POST con mock auth retorna 201
- `test_create_service_invalid_payload_returns_422` — precio negativo retorna 422
- `test_update_service` — PATCH con mock auth retorna 200
- `test_delete_service_without_auth_returns_401` — DELETE sin auth retorna 401
- `test_delete_service_with_auth` — DELETE con mock auth retorna 204
- `test_get_service_not_found` — GET servicio inexistente retorna 404

**8 tests, 8 passing**

## Migration
- `supabase/migrations/20260324000003_services.sql` — ejecutar manualmente en Supabase SQL editor

## Deploy
- [ ] QA/DevOps: `cd infra/docker && docker compose up -d --build`

Closes #10