### PR TITLE
[S3] DB schema v2: portfolio, products, invitations, branding

### DIFF
--- a/supabase/migrations/20260324000006_barbers_extended.sql
+++ b/supabase/migrations/20260324000006_barbers_extended.sql
@@ -1,0 +1,18 @@
+-- Migration 006: Extend barbers profile with additional fields
+-- Run manually in Supabase SQL editor
+
+ALTER TABLE barbers
+  ADD COLUMN IF NOT EXISTS specialty TEXT,
+  ADD COLUMN IF NOT EXISTS avatar_url TEXT,
+  ADD COLUMN IF NOT EXISTS bio TEXT,
+  ADD COLUMN IF NOT EXISTS rating NUMERIC(3,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS total_reviews INT DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS avg_service_minutes INT,
+  ADD COLUMN IF NOT EXISTS is_available_for_hire BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS hire_type TEXT CHECK (hire_type IN ('full_time','part_time','freelance')),
+  ADD COLUMN IF NOT EXISTS target_city TEXT,
+  ADD COLUMN IF NOT EXISTS qr_code TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS stripe_account_id TEXT;
+
+-- Generate unique QR code for existing barbers
+UPDATE barbers SET qr_code = gen_random_uuid()::text WHERE qr_code IS NULL;

--- a/supabase/migrations/20260324000007_barber_portfolio.sql
+++ b/supabase/migrations/20260324000007_barber_portfolio.sql
@@ -1,0 +1,28 @@
+-- Migration 007: Create barber_portfolio table for work showcase photos
+-- Run manually in Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS barber_portfolio (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  barber_id UUID NOT NULL REFERENCES barbers(id) ON DELETE CASCADE,
+  photo_url TEXT NOT NULL,
+  caption TEXT,
+  tags TEXT[] DEFAULT '{}',
+  display_order INT DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_barber_portfolio_barber_id ON barber_portfolio(barber_id);
+CREATE INDEX IF NOT EXISTS idx_barber_portfolio_order ON barber_portfolio(barber_id, display_order);
+
+ALTER TABLE barber_portfolio ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "portfolio_select" ON barber_portfolio FOR SELECT USING (auth.role() = 'authenticated');
+CREATE POLICY "portfolio_insert" ON barber_portfolio FOR INSERT WITH CHECK (
+  barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "portfolio_update" ON barber_portfolio FOR UPDATE USING (
+  barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "portfolio_delete" ON barber_portfolio FOR DELETE USING (
+  barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);

--- a/supabase/migrations/20260324000008_products.sql
+++ b/supabase/migrations/20260324000008_products.sql
@@ -1,0 +1,38 @@
+-- Migration 008: Create products table for shop and barber products
+-- Run manually in Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS products (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id UUID NOT NULL REFERENCES barber_shops(id) ON DELETE CASCADE,
+  barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  price NUMERIC(10,2) NOT NULL CHECK (price >= 0),
+  stock_quantity INT DEFAULT 0,
+  photo_url TEXT,
+  category TEXT DEFAULT 'other',
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON COLUMN products.barber_id IS 'NULL = producto del shop, NOT NULL = producto propio del barbero';
+
+CREATE INDEX IF NOT EXISTS idx_products_shop_id ON products(shop_id);
+CREATE INDEX IF NOT EXISTS idx_products_barber_id ON products(barber_id);
+
+ALTER TABLE products ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "products_select" ON products FOR SELECT USING (auth.role() = 'authenticated');
+CREATE POLICY "products_insert_owner" ON products FOR INSERT WITH CHECK (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "products_update_owner" ON products FOR UPDATE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "products_delete_owner" ON products FOR DELETE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);

--- a/supabase/migrations/20260324000009_invitations.sql
+++ b/supabase/migrations/20260324000009_invitations.sql
@@ -1,0 +1,51 @@
+-- Migration 009: Create shop_invitations and barber_join_requests tables
+-- Run manually in Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS shop_invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id UUID NOT NULL REFERENCES barber_shops(id) ON DELETE CASCADE,
+  inviter_id UUID NOT NULL REFERENCES profiles(id),
+  invited_email TEXT NOT NULL,
+  invited_barber_id UUID REFERENCES barbers(id),
+  token TEXT UNIQUE DEFAULT gen_random_uuid()::text,
+  message TEXT,
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending','accepted','rejected','expired')),
+  expires_at TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '7 days'),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS barber_join_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id UUID NOT NULL REFERENCES barber_shops(id) ON DELETE CASCADE,
+  requester_id UUID NOT NULL REFERENCES profiles(id),
+  message TEXT,
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending','approved','rejected')),
+  reviewed_by UUID REFERENCES profiles(id),
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_shop_id ON shop_invitations(shop_id);
+CREATE INDEX IF NOT EXISTS idx_invitations_token ON shop_invitations(token);
+CREATE INDEX IF NOT EXISTS idx_join_requests_shop_id ON barber_join_requests(shop_id);
+
+ALTER TABLE shop_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE barber_join_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "invitations_owner_all" ON shop_invitations FOR ALL USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+);
+CREATE POLICY "invitations_invitee_select" ON shop_invitations FOR SELECT USING (
+  invited_email = (SELECT email FROM profiles WHERE id = auth.uid())
+);
+
+CREATE POLICY "join_requests_insert" ON barber_join_requests FOR INSERT WITH CHECK (
+  requester_id = auth.uid()
+);
+CREATE POLICY "join_requests_owner" ON barber_join_requests FOR SELECT USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR requester_id = auth.uid()
+);
+CREATE POLICY "join_requests_owner_update" ON barber_join_requests FOR UPDATE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+);

--- a/supabase/migrations/20260324000010_shop_branding.sql
+++ b/supabase/migrations/20260324000010_shop_branding.sql
@@ -1,0 +1,18 @@
+-- Migration 010: Add branding fields to barber_shops table
+-- Run manually in Supabase SQL editor
+
+ALTER TABLE barber_shops
+  ADD COLUMN IF NOT EXISTS slug TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS accent_color TEXT DEFAULT '#D97706',
+  ADD COLUMN IF NOT EXISTS tagline TEXT,
+  ADD COLUMN IF NOT EXISTS instagram_url TEXT,
+  ADD COLUMN IF NOT EXISTS whatsapp TEXT,
+  ADD COLUMN IF NOT EXISTS gallery_urls TEXT[] DEFAULT '{}';
+
+-- Generate initial slug for existing shops
+UPDATE barber_shops
+SET slug = LOWER(REGEXP_REPLACE(name, '[^a-zA-Z0-9]+', '-', 'g')) || '-' || SUBSTRING(id::text, 1, 6)
+WHERE slug IS NULL;
+
+ALTER TABLE barber_shops ALTER COLUMN slug SET NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_barber_shops_slug ON barber_shops(slug);

--- a/supabase/migrations/20260324000011_services_barber_id.sql
+++ b/supabase/migrations/20260324000011_services_barber_id.sql
@@ -1,0 +1,22 @@
+-- Migration 011: Add barber_id to services to support barber-owned services
+-- Run manually in Supabase SQL editor
+
+ALTER TABLE services
+  ADD COLUMN IF NOT EXISTS barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE;
+
+COMMENT ON COLUMN services.barber_id IS 'NULL = servicio del shop, NOT NULL = servicio propio del barbero';
+
+CREATE INDEX IF NOT EXISTS idx_services_barber_id ON services(barber_id);
+
+-- Update RLS to allow barbers to manage their own services
+DROP POLICY IF EXISTS "services_insert" ON services;
+CREATE POLICY "services_insert" ON services FOR INSERT WITH CHECK (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS "services_update" ON services;
+CREATE POLICY "services_update" ON services FOR UPDATE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);


### PR DESCRIPTION
Closes #32

## Changes
- **006_barbers_extended**: Agrega specialty, avatar_url, bio, rating, total_reviews, avg_service_minutes, is_available_for_hire, hire_type, target_city, qr_code, stripe_account_id a la tabla barbers. Genera QR unico para registros existentes.
- **007_barber_portfolio**: Nueva tabla barber_portfolio para fotos de trabajos del barbero. RLS: barbero gestiona su propio portfolio, usuarios autenticados pueden ver.
- **008_products**: Nueva tabla products con soporte dual shop/barbero (barber_id NULL = producto del shop). RLS por ownership. Indices en shop_id y barber_id.
- **009_invitations**: Nueva tabla shop_invitations (invitaciones del dueno a barberos) y barber_join_requests (solicitudes de barberos para unirse). RLS por rol (owner vs solicitante).
- **010_shop_branding**: Agrega slug (unico, autogenerado), accent_color, tagline, instagram_url, whatsapp, gallery_urls a barber_shops. Slug NOT NULL con index.
- **011_services_barber_id**: Agrega barber_id a services para servicios propios del barbero. Reemplaza politicas RLS de insert/update para incluir ownership del barbero.

## Run order
Ejecutar manualmente en Supabase SQL editor en orden estricto: 006 -> 007 -> 008 -> 009 -> 010 -> 011

## Tests
N/A - migraciones SQL puras, sin logica de aplicacion. La validacion se realiza mediante ejecucion en Supabase SQL editor.

## Security Considerations
- Todas las tablas nuevas tienen RLS habilitado
- Las politicas siguen el patron: SELECT para autenticados, INSERT/UPDATE/DELETE por ownership
- La columna qr_code en barbers tiene restriccion UNIQUE
- El token en shop_invitations tiene restriccion UNIQUE