### PR TITLE
[S3] Shop branding API — slug, colores, galeria, horarios

### DIFF
--- a/supabase/migrations/20260324000006_barbers_extended.sql
+++ b/supabase/migrations/20260324000006_barbers_extended.sql
@@ -1,0 +1,18 @@
+-- Migration 006: Extend barbers profile with additional fields
+-- Run manually in Supabase SQL editor
+
+ALTER TABLE barbers
+  ADD COLUMN IF NOT EXISTS specialty TEXT,
+  ADD COLUMN IF NOT EXISTS avatar_url TEXT,
+  ADD COLUMN IF NOT EXISTS bio TEXT,
+  ADD COLUMN IF NOT EXISTS rating NUMERIC(3,2) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS total_reviews INT DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS avg_service_minutes INT,
+  ADD COLUMN IF NOT EXISTS is_available_for_hire BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS hire_type TEXT CHECK (hire_type IN ('full_time','part_time','freelance')),
+  ADD COLUMN IF NOT EXISTS target_city TEXT,
+  ADD COLUMN IF NOT EXISTS qr_code TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS stripe_account_id TEXT;
+
+-- Generate unique QR code for existing barbers
+UPDATE barbers SET qr_code = gen_random_uuid()::text WHERE qr_code IS NULL;

--- a/supabase/migrations/20260324000007_barber_portfolio.sql
+++ b/supabase/migrations/20260324000007_barber_portfolio.sql
@@ -1,0 +1,28 @@
+-- Migration 007: Create barber_portfolio table for work showcase photos
+-- Run manually in Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS barber_portfolio (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  barber_id UUID NOT NULL REFERENCES barbers(id) ON DELETE CASCADE,
+  photo_url TEXT NOT NULL,
+  caption TEXT,
+  tags TEXT[] DEFAULT '{}',
+  display_order INT DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_barber_portfolio_barber_id ON barber_portfolio(barber_id);
+CREATE INDEX IF NOT EXISTS idx_barber_portfolio_order ON barber_portfolio(barber_id, display_order);
+
+ALTER TABLE barber_portfolio ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "portfolio_select" ON barber_portfolio FOR SELECT USING (auth.role() = 'authenticated');
+CREATE POLICY "portfolio_insert" ON barber_portfolio FOR INSERT WITH CHECK (
+  barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "portfolio_update" ON barber_portfolio FOR UPDATE USING (
+  barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "portfolio_delete" ON barber_portfolio FOR DELETE USING (
+  barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);

--- a/supabase/migrations/20260324000008_products.sql
+++ b/supabase/migrations/20260324000008_products.sql
@@ -1,0 +1,38 @@
+-- Migration 008: Create products table for shop and barber products
+-- Run manually in Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS products (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id UUID NOT NULL REFERENCES barber_shops(id) ON DELETE CASCADE,
+  barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  price NUMERIC(10,2) NOT NULL CHECK (price >= 0),
+  stock_quantity INT DEFAULT 0,
+  photo_url TEXT,
+  category TEXT DEFAULT 'other',
+  is_active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON COLUMN products.barber_id IS 'NULL = producto del shop, NOT NULL = producto propio del barbero';
+
+CREATE INDEX IF NOT EXISTS idx_products_shop_id ON products(shop_id);
+CREATE INDEX IF NOT EXISTS idx_products_barber_id ON products(barber_id);
+
+ALTER TABLE products ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "products_select" ON products FOR SELECT USING (auth.role() = 'authenticated');
+CREATE POLICY "products_insert_owner" ON products FOR INSERT WITH CHECK (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "products_update_owner" ON products FOR UPDATE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+CREATE POLICY "products_delete_owner" ON products FOR DELETE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);

--- a/supabase/migrations/20260324000009_invitations.sql
+++ b/supabase/migrations/20260324000009_invitations.sql
@@ -1,0 +1,51 @@
+-- Migration 009: Create shop_invitations and barber_join_requests tables
+-- Run manually in Supabase SQL editor
+
+CREATE TABLE IF NOT EXISTS shop_invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id UUID NOT NULL REFERENCES barber_shops(id) ON DELETE CASCADE,
+  inviter_id UUID NOT NULL REFERENCES profiles(id),
+  invited_email TEXT NOT NULL,
+  invited_barber_id UUID REFERENCES barbers(id),
+  token TEXT UNIQUE DEFAULT gen_random_uuid()::text,
+  message TEXT,
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending','accepted','rejected','expired')),
+  expires_at TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '7 days'),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS barber_join_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  shop_id UUID NOT NULL REFERENCES barber_shops(id) ON DELETE CASCADE,
+  requester_id UUID NOT NULL REFERENCES profiles(id),
+  message TEXT,
+  status TEXT DEFAULT 'pending' CHECK (status IN ('pending','approved','rejected')),
+  reviewed_by UUID REFERENCES profiles(id),
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invitations_shop_id ON shop_invitations(shop_id);
+CREATE INDEX IF NOT EXISTS idx_invitations_token ON shop_invitations(token);
+CREATE INDEX IF NOT EXISTS idx_join_requests_shop_id ON barber_join_requests(shop_id);
+
+ALTER TABLE shop_invitations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE barber_join_requests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "invitations_owner_all" ON shop_invitations FOR ALL USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+);
+CREATE POLICY "invitations_invitee_select" ON shop_invitations FOR SELECT USING (
+  invited_email = (SELECT email FROM profiles WHERE id = auth.uid())
+);
+
+CREATE POLICY "join_requests_insert" ON barber_join_requests FOR INSERT WITH CHECK (
+  requester_id = auth.uid()
+);
+CREATE POLICY "join_requests_owner" ON barber_join_requests FOR SELECT USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR requester_id = auth.uid()
+);
+CREATE POLICY "join_requests_owner_update" ON barber_join_requests FOR UPDATE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+);

--- a/supabase/migrations/20260324000010_shop_branding.sql
+++ b/supabase/migrations/20260324000010_shop_branding.sql
@@ -1,0 +1,18 @@
+-- Migration 010: Add branding fields to barber_shops table
+-- Run manually in Supabase SQL editor
+
+ALTER TABLE barber_shops
+  ADD COLUMN IF NOT EXISTS slug TEXT UNIQUE,
+  ADD COLUMN IF NOT EXISTS accent_color TEXT DEFAULT '#D97706',
+  ADD COLUMN IF NOT EXISTS tagline TEXT,
+  ADD COLUMN IF NOT EXISTS instagram_url TEXT,
+  ADD COLUMN IF NOT EXISTS whatsapp TEXT,
+  ADD COLUMN IF NOT EXISTS gallery_urls TEXT[] DEFAULT '{}';
+
+-- Generate initial slug for existing shops
+UPDATE barber_shops
+SET slug = LOWER(REGEXP_REPLACE(name, '[^a-zA-Z0-9]+', '-', 'g')) || '-' || SUBSTRING(id::text, 1, 6)
+WHERE slug IS NULL;
+
+ALTER TABLE barber_shops ALTER COLUMN slug SET NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_barber_shops_slug ON barber_shops(slug);

--- a/supabase/migrations/20260324000011_services_barber_id.sql
+++ b/supabase/migrations/20260324000011_services_barber_id.sql
@@ -1,0 +1,22 @@
+-- Migration 011: Add barber_id to services to support barber-owned services
+-- Run manually in Supabase SQL editor
+
+ALTER TABLE services
+  ADD COLUMN IF NOT EXISTS barber_id UUID REFERENCES barbers(id) ON DELETE CASCADE;
+
+COMMENT ON COLUMN services.barber_id IS 'NULL = servicio del shop, NOT NULL = servicio propio del barbero';
+
+CREATE INDEX IF NOT EXISTS idx_services_barber_id ON services(barber_id);
+
+-- Update RLS to allow barbers to manage their own services
+DROP POLICY IF EXISTS "services_insert" ON services;
+CREATE POLICY "services_insert" ON services FOR INSERT WITH CHECK (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);
+
+DROP POLICY IF EXISTS "services_update" ON services;
+CREATE POLICY "services_update" ON services FOR UPDATE USING (
+  shop_id IN (SELECT id FROM barber_shops WHERE owner_id = auth.uid())
+  OR barber_id IN (SELECT id FROM barbers WHERE user_id = auth.uid())
+);


### PR DESCRIPTION
Closes #36.

## Changes
- `ShopBrandingUpdate`: slug (regex `^[a-z0-9-]{3,50}$`), accent_color (hex `#RRGGBB`), tagline, instagram_url, whatsapp
- `ShopHoursUpdate`: objeto con días de la semana, cada uno con `open`, `close`, `is_open`
- `ShopGalleryResponse`: lista de `gallery_urls`
- `PATCH /barber-shops/{shop_id}/branding`: actualiza branding, valida slug único (409 si duplicado), owner only
- `PATCH /barber-shops/{shop_id}/hours`: upsert por día de semana, owner only
- `POST /barber-shops/{shop_id}/gallery`: agrega foto, máximo 10 (400 si llena), owner only
- `DELETE /barber-shops/{shop_id}/gallery/{index}`: elimina foto por índice, owner only
- `GET /barber-shops/{shop_id}/public`: perfil público completo con branding y galería

## Tests
9 tests, 9 passing (test_shop_branding.py):
- test_update_branding_slug (happy path)
- test_update_branding_duplicate_slug (409)
- test_update_branding_invalid_color (422)
- test_update_hours
- test_add_gallery_photo
- test_gallery_max_10_photos (400)
- test_unauthorized_branding_update (403)
- test_get_shop_public
- test_update_branding_without_auth_returns_401 (401)

Sin regresiones: 10/10 tests previos de test_barber_shops.py siguen pasando.